### PR TITLE
Update tquic version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tquic-example-rust"
-version = "0.3.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.70.0"
 license = "Apache-2.0"
@@ -9,7 +9,7 @@ homepage = "https://tquic.net"
 description = "TQUIC example client and server"
 
 [dependencies]
-tquic = "0.3.0"
+tquic = "0.5.0"
 bytes = "1"
 log = "0.4"
 mio = { version = "0.8", features = ["net", "os-poll"] }


### PR DESCRIPTION
If someone wants to develop based on the previous example, the old tquic version may lead to unexpected compilation errors.